### PR TITLE
makes addition of route idempotent 

### DIFF
--- a/apps/navstar_l4lb/src/navstar_l4lb_route_mgr.erl
+++ b/apps/navstar_l4lb/src/navstar_l4lb_route_mgr.erl
@@ -199,7 +199,7 @@ add_route(Dst, #state{netlink = Pid, iface = Iface}) ->
         _Type = local,
         _Flags = [],
         Msg},
-    {ok, _} = gen_netlink_client:rtnl_request(Pid, newroute, [create, excl], Route).
+    {ok, _} = gen_netlink_client:rtnl_request(Pid, newroute, [create, replace], Route).
 
 remove_route(Dst, #state{netlink = Pid, iface = Iface}) ->
     Msg = [{table, ?LOCAL_TABLE}, {dst, Dst}, {oif, Iface}],


### PR DESCRIPTION
It has been observed that certain time the route is already present in the kernel. This could happen if the cleanup didn't happen properly. This patch fixes the problem by making the addition of new route idempotent so that it would pass even if the route is already present.