### PR TITLE
make periodic reconcile

### DIFF
--- a/apps/navstar_l4lb/src/navstar_l4lb_ipvs_mgr.erl
+++ b/apps/navstar_l4lb/src/navstar_l4lb_ipvs_mgr.erl
@@ -322,6 +322,7 @@ handle_remove_service(IP, Port, Protocol, Namespace, State) ->
 
 -spec(handle_remove_service(Service :: service(), Namespace :: term(), State :: state()) -> ok | error).
 handle_remove_service(Service, Namespace, #state{netns = NetnsMap, family = Family}) ->
+    lager:info("Namespace: ~p, Removing Service: ~p", [Namespace, Service]),
     Pid = maps:get(Namespace, NetnsMap),
     case gen_netlink_client:request(Pid, Family, ipvs, [], #del_service{request = [{service, Service}]}) of
         {ok, _} -> ok;
@@ -342,7 +343,7 @@ handle_add_service(IP, Port, Protocol, Namespace, #state{netns = NetnsMap, famil
         {timeout, 0}
     ],
     Service1 = ip_to_address(IP) ++ Service0,
-    lager:info("Adding Service: ~p", [Service1]),
+    lager:info("Namespace: ~p, Adding Service: ~p", [Namespace, Service1]),
     case gen_netlink_client:request(Pid, Family, ipvs, [], #new_service{request = [{service, Service1}]}) of
         {ok, _} -> ok;
         _ -> error
@@ -386,7 +387,7 @@ handle_remove_dest(ServiceIP, ServicePort, DestIP, DestPort, Protocol, Namespace
 
 -spec(handle_remove_dest(Service :: service(), Dest :: dest(), Namespace :: term(), State :: state()) -> ok | error).
 handle_remove_dest(Service, Dest, Namespace, #state{netns = NetnsMap, family = Family}) ->
-    lager:info("Deleting Dest: ~p~n", [Dest]),
+    lager:info("Removing Dest ~p to service ~p~n", [Dest, Service]),
     Pid = maps:get(Namespace, NetnsMap),
     Msg = #del_dest{request = [{dest, Dest}, {service, Service}]},
     case gen_netlink_client:request(Pid, Family, ipvs, [], Msg) of

--- a/apps/navstar_l4lb/src/navstar_l4lb_mgr.erl
+++ b/apps/navstar_l4lb/src/navstar_l4lb_mgr.erl
@@ -18,6 +18,9 @@
 -include_lib("gen_netlink/include/netlink.hrl").
 -include("navstar_l4lb_lashup.hrl").
 -include("navstar_l4lb.hrl").
+
+-define(NOW, 0).
+-define(RECONCILE_TIMEOUT, 30000).
 -define(SERVER, ?MODULE).
 
 -record(state, {
@@ -120,24 +123,26 @@ reconcile(cast, {netns_event, Ref, EventType, EventContent}, State0 = #state{net
 
 maintain(cast, {vips, VIPs}, State0) ->
     State1 = maintain(VIPs, State0),
-    {keep_state, State1};
+    {keep_state, State1, {timeout, ?RECONCILE_TIMEOUT, do_reconcile}};
 maintain(internal, maintain, State0 = #state{last_received_vips = VIPs}) ->
     State1 = maintain(VIPs, State0),
-    {keep_state, State1};
+    {keep_state, State1, {timeout, ?RECONCILE_TIMEOUT, do_reconcile}};
 maintain(info, {lashup_gm_route_events, #{ref := Ref, tree := Tree}}, State0 = #state{route_events_ref = Ref}) ->
     State1 = State0#state{tree = Tree},
     {keep_state, State1, {next_event, internal, maintain}};
 maintain(info, {lashup_kv_events, Event = #{ref := Ref}}, State0 = #state{kv_ref = Ref}) ->
     State1 = handle_ip_event(Event, State0),
-    {keep_state, State1};
+    {keep_state, State1, {timeout, ?RECONCILE_TIMEOUT, do_reconcile}};
 maintain(cast, {netns_event, Ref, reconcile_netns, EventContent}, 
-         State0 = #state{last_configured_vips = VIPs, netns_event_ref = Ref}) ->
+         State0 = #state{netns_event_ref = Ref}) ->
     State1 = update_netns(reconcile_netns, EventContent, State0),
-    State2 = do_reconcile(VIPs, State1),
-    {keep_state, State2};
+    {keep_state, State1, {timeout, ?NOW, do_reconcile}};
 maintain(cast, {netns_event, Ref, EventType, EventContent}, State0 = #state{netns_event_ref = Ref}) -> 
     State1 = update_netns(EventType, EventContent, State0),
-    {keep_state, State1}.
+    {keep_state, State1, {timeout, ?RECONCILE_TIMEOUT, do_reconcile}};
+maintain(timeout, do_reconcile, State0 = #state{last_received_vips = VIPs}) ->
+    State1 = do_reconcile(VIPs, State0),
+    {keep_state, State1, {timeout, ?RECONCILE_TIMEOUT, do_reconcile}}.
 
 handle_ip_event(_Event = #{value := Value}, State0) ->
     IPToNodeName = [{IP, NodeName} || {?LWW_REG(IP), NodeName} <- Value],

--- a/apps/navstar_l4lb/src/navstar_l4lb_route_mgr.erl
+++ b/apps/navstar_l4lb/src/navstar_l4lb_route_mgr.erl
@@ -213,11 +213,11 @@ route_msg_oif(Msg) -> proplists:get_value(oif, element(10, Msg)).
 route_msg_dst(Msg) -> proplists:get_value(dst, element(10, Msg)).
 
 handle_add_routes(RoutesToAdd, Namespace, State) ->
-    lager:info("Adding routes to Namespace ~p ~p", [Namespace, RoutesToAdd]),
+    lager:info("Namespace: ~p, Adding routes: ~p", [Namespace, RoutesToAdd]),
     lists:foreach(fun(Route) -> add_route(Route, Namespace, State) end, RoutesToAdd).
 
 handle_remove_routes(RoutesToDelete, Namespace, State) ->
-    lager:info("Removing routes from Namespace ~p ~p", [Namespace, RoutesToDelete]),
+    lager:info("Namespace: ~p, Removing routes: ~p", [Namespace, RoutesToDelete]),
     lists:foreach(fun(Route) -> remove_route(Route, Namespace, State) end, RoutesToDelete).
  
 add_route(Dst, Namespace, #state{netns = NetnsMap}) ->


### PR DESCRIPTION
Today, its possible to remove ipvs configuration under the hood which breaks the load balancing functionality thereon. This patch adds periodic reconcile in navstar_l4lb to check if the kernel configuration match with the desired configuration and reapply the configuration if it is absent.